### PR TITLE
Feature: Local custodian code filter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ Temporary home for our OS Places [PHP Geocoder](https://geocoder-php.org/) provi
 
 PHP Geocoder plugin for the [Ordnance Survey Places API](https://osdatahub.os.uk/docs/places/overview).  Looks up addresses based on the given street address or postcode.  Resultant addresses include both Easting and Northing as well as latitude and longitude as location coordinates.  The values of Easting and Northing are in the [All numeric grid reference](https://en.wikipedia.org/wiki/Ordnance_Survey_National_Grid#All-numeric_grid_references) format.
 
+Search results can be filtered for a single local authority based on its [Local custodian code](https://www.ordnancesurvey.co.uk/documents/product-support/support/addressbase-local-custodian-codes.zip).
+
 This Geocoder requires an API key.
 
 ## Installation
@@ -29,6 +31,12 @@ $our_api_key        = 'API-KEY-GOES-HERE';
 
 $provider = new OsPlacesGeocoder($http_client, $generic_query_url, $postcode_query_url, $our_api_key);
 $result   = $provider->geocodeQuery(GeocodeQuery::create('BN1 1JE'));
+$address  = $result->first()->toArray();
+print_r($address);
+
+// Restrict lookup to a single local authority.
+$query    = GeocodeQuery::create('Brighton pier')->withData('local_custodian_code', 1445);
+$result   = $provider->geocodeQuery($query);
 $address  = $result->first()->toArray();
 print_r($address);
 ```

--- a/src/Provider/OsPlacesGeocoder.php
+++ b/src/Provider/OsPlacesGeocoder.php
@@ -18,8 +18,11 @@ use LocalgovDrupal\OsPlacesGeocoder\Model\OsPlacesAddress;
 /**
  * Geocoder plugin for the Ordnance Survey Places API.
  *
- * Lists addresses based on given postcode or address string.  Addresses are
- * keyed by their UPRN.
+ * Lists addresses based on given postcode or address string.  Results can be
+ * restricted to a single local authority through the `local_custodian_code`
+ * data parameter.
+ *
+ * Addresses are keyed by their UPRN.
  *
  * @see https://osdatahub.os.uk/docs/places/overview
  * @see https://en.wikipedia.org/wiki/Unique_Property_Reference_Number
@@ -65,6 +68,10 @@ class OsPlacesGeocoder extends AbstractHttpProvider implements GeocoderProviderI
     }
 
     $search_query['output_srs'] = self::OS_OUTPUT_FORMAT_WITH_LAT_LON;
+
+    if ($local_custodian_code = $query->getData('local_custodian_code', FALSE)) {
+      $search_query['fq'] = "LOCAL_CUSTODIAN_CODE:$local_custodian_code";
+    }
 
     $api_url = sprintf('%s?%s', $api_endpoint, http_build_query($search_query));
     $request = $this->getRequest($api_url);

--- a/src/Provider/OsPlacesGeocoder.php
+++ b/src/Provider/OsPlacesGeocoder.php
@@ -68,9 +68,8 @@ class OsPlacesGeocoder extends AbstractHttpProvider implements GeocoderProviderI
     }
 
     $search_query['output_srs'] = self::OS_OUTPUT_FORMAT_WITH_LAT_LON;
-
     if ($local_custodian_code = $query->getData('local_custodian_code', FALSE)) {
-      $search_query['fq'] = "LOCAL_CUSTODIAN_CODE:$local_custodian_code";
+      $search_query['fq'] = 'LOCAL_CUSTODIAN_CODE:' . (int) $local_custodian_code;
     }
 
     $api_url = sprintf('%s?%s', $api_endpoint, http_build_query($search_query));


### PR DESCRIPTION
The local custodian code is a numeric code used by the [OS Places API](https://osdatahub.os.uk/docs/match/technicalSpecificatio).  Every local authority has been assigned a [code](https://www.ordnancesurvey.co.uk/documents/product-support/support/addressbase-local-custodian-codes.zip).  This change extends OsPlacesGeocoder to filter all results based on a given local custodian code.