### PR TITLE
Allow willdurand/geocoder (^4.0|^5.0)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "minimum-stability": "dev",
   "require": {
     "geocoder-php/common-http": "^4.1",
-    "willdurand/geocoder": "^4.0"
+    "willdurand/geocoder": "^4.0|^5.0"
   },
   "require-dev": {
     "geocoder-php/provider-integration-tests": "^1.0",


### PR DESCRIPTION
Fixes #8 

Allow willdurand/geocoder (^4.0|^5.0)